### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: generic
+env:
+  global:
+    - IDE_VERSION=1.6.8
+  matrix:
+    - BOARD="arduino:samd:arduino_zero_edbg"
+    - BOARD="arduino:samd:mkr1000"
+    - BOARD="esp8266:esp8266:huzzah"
+    - BOARD="esp8266:esp8266:thing"
+matrix:
+  allow_failures:
+    - env: BOARD="esp8266:esp8266:huzzah"
+before_install:
+  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
+  - sleep 3
+  - export DISPLAY=:1.0
+  - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
+  - tar xf arduino-$IDE_VERSION-linux64.tar.xz
+  - mv arduino-$IDE_VERSION $HOME/arduino-ide
+  - export PATH=$PATH:$HOME/arduino-ide
+  - if [[ "$BOARD" =~ "arduino:samd:" ]]; then
+      arduino --install-boards arduino:samd;
+      arduino --install-library WiFi101;
+      arduino --install-library RTCZero;
+      arduino --install-library "Adafruit BME280 Library";
+      export SUBFOLDER="samd";
+    fi
+  - if [[ "$BOARD" =~ "esp8266:esp8266:" ]]; then
+      arduino --pref "boardsmanager.additional.urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json" --install-boards esp8266:esp8266;
+      arduino --pref "boardsmanager.additional.urls=" --save-prefs;
+      arduino --install-library "DHT sensor library";
+      arduino --install-library "Adafruit DHT Unified";
+      export SUBFOLDER="esp8266";
+    fi
+  - arduino --install-library "Adafruit Unified Sensor"
+  - buildExampleSketch() { arduino --verbose-build --verify --board $BOARD $PWD/examples/$SUBFOLDER/$1/$1.ino; }
+install:
+  - mkdir -p $HOME/Arduino/libraries
+  - ln -s $PWD $HOME/Arduino/libraries/.
+script:
+  - buildExampleSketch command_center
+  - buildExampleSketch remote_monitoring
+  - buildExampleSketch simplesample_http

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,20 +22,46 @@ before_install:
       arduino --install-boards arduino:samd;
       arduino --install-library WiFi101;
       arduino --install-library RTCZero;
-      arduino --install-library "Adafruit BME280 Library";
-      export SUBFOLDER="samd";
     fi
   - if [[ "$BOARD" =~ "esp8266:esp8266:" ]]; then
       arduino --pref "boardsmanager.additional.urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json" --install-boards esp8266:esp8266;
       arduino --pref "boardsmanager.additional.urls=" --save-prefs;
-      arduino --install-library "DHT sensor library";
-      arduino --install-library "Adafruit DHT Unified";
-      export SUBFOLDER="esp8266";
     fi
   - arduino --install-library "Adafruit Unified Sensor"
-  - buildExampleSketch() { arduino --verbose-build --verify --board $BOARD $PWD/examples/$SUBFOLDER/$1/$1.ino; }
-install:
+  - arduino --install-library "Adafruit BME280 Library";
   - mkdir -p $HOME/Arduino/libraries
+  - git clone https://github.com/arduino-libraries/NTPClient.git $HOME/Arduino/libraries/NTPClient
+  - findAndReplace() { sed -i'' -e"s|$1|$2|g" "$3"; }
+  - buildExampleSketch() {
+      EXAMPLE_SKETCH=$PWD/examples/$1/$1.ino;
+
+      if [[ "$BOARD" =~ "arduino:samd:" ]]; then
+        findAndReplace "Adafruit_WINC1500 WiFi" "//Adafruit_WINC1500 WiFi" $EXAMPLE_SKETCH;
+
+        findAndReplace Adafruit_WINC1500Udp WiFiUdp $EXAMPLE_SKETCH;
+        findAndReplace Adafruit_WINC1500UDP WiFiUDP $EXAMPLE_SKETCH;
+        findAndReplace Adafruit_WINC1500SSLClient WiFiSSLClient $EXAMPLE_SKETCH;
+        findAndReplace Adafruit_WINC1500 WiFi101 $EXAMPLE_SKETCH;        
+      fi
+
+      if [[ "$BOARD" =~ "esp8266:esp8266:" ]]; then
+        findAndReplace "Adafruit_WINC1500 WiFi" "//Adafruit_WINC1500 WiFi" $EXAMPLE_SKETCH;
+
+        findAndReplace WiFi101 ESP8266WiFi $EXAMPLE_SKETCH;
+        findAndReplace WiFiSSLClient WiFiClientSecure $EXAMPLE_SKETCH;
+        findAndReplace WiFiUdp WiFiUdp $EXAMPLE_SKETCH;
+
+        findAndReplace Adafruit_WINC1500Udp WiFiUdp $EXAMPLE_SKETCH;
+        findAndReplace Adafruit_WINC1500UDP WiFiUDP $EXAMPLE_SKETCH;
+        findAndReplace Adafruit_WINC1500SSLClient WiFiClientSecure $EXAMPLE_SKETCH;
+        findAndReplace Adafruit_WINC1500 ESP8266WiFi $EXAMPLE_SKETCH;        
+      fi
+
+      cat $EXAMPLE_SKETCH;
+
+      arduino --verbose-build --verify --board $BOARD $EXAMPLE_SKETCH;
+    }
+install:
   - ln -s $PWD $HOME/Arduino/libraries/.
 script:
   - buildExampleSketch command_center

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AzureIoTHub - Azure IoT Hub library for Arduino
 
+[![Build Status](https://travis-ci.org/arduino-libraries/AzureIoT.svg?branch=master)](https://travis-ci.org/arduino-libraries/AzureIoT)
+
 This library is a port of the [Microsoft Azure IoT device SDK for C](https://github.com/Azure/azure-iot-sdks/blob/master/c/readme.md) to Arduino. It allows you to use several Arduino compatible boards with Azure IoT Hub.
 
 Currently supported hardware:

--- a/examples/command_center/rem_ctrl_http.c
+++ b/examples/command_center/rem_ctrl_http.c
@@ -231,7 +231,7 @@ void rem_ctrl_http_send_data(float Temp_c__f, float Pres_hPa__f, float Humi_pct_
     if (Init_level__i < 4) return;
 
     timeNow = (int)time(NULL);
-    sLogInfo(buff, "%d", timeNow);
+    sprintf(buff, "%d", timeNow);
     
     myWeather->DeviceId = "FeatherM0_w_BME280";
     myWeather->MTemperature = Temp_c__f;

--- a/src/esp8266/libc_esp.c
+++ b/src/esp8266/libc_esp.c
@@ -16,7 +16,7 @@ int fprintf(FILE* file, const char* format, ...) {
     int ret;
     va_list arglist;
     va_start(arglist, format);
-    ret = ets_vprintf(format, arglist);
+    ret = ets_vprintf(ets_putc, format, arglist);
     va_end(arglist);
     return ret;
 }


### PR DESCRIPTION
Resolves #3.

The ESP8266 Huzzah build is currently set to allow failures because a .ld is missing. I've also left out testing the Adafruit Feather M0 board because the Adafruit WINC1500 wifi library is not in the library manager, we can figure out an alternative later on.

@stefangordon @obsoleted please review.